### PR TITLE
Improvements

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,33 +5,30 @@ export default function useAppState(settings) {
   const { onChange, onForeground, onBackground } = settings || {};
   const [appState, setAppState] = useState(AppState.currentState);
 
-  function handleAppStateChange(nextAppState) {
-    if (nextAppState === 'active') {
-      isValidFunction(onForeground) && onForeground();
-    } else if (
-      appState === 'active' &&
-      nextAppState.match(/inactive|background/)
-    ) {
-      // to ensure that onBackground() is not called twice we
-      // check if the previous app state was 'active' as iOS
-      // has two not-active-states (inactive and background)
-      isValidFunction(onBackground) && onBackground();
-    }
-    setAppState(nextAppState);
-    isValidFunction(onChange) && onChange(nextAppState);
-  }
-
   // didMount effect
   useEffect(() => {
+    function handleAppStateChange(nextAppState) {
+      if (nextAppState === 'active') {
+        isValidFunction(onForeground) && onForeground();
+      } else if (
+        appState === 'active' &&
+        nextAppState.match(/inactive|background/)
+      ) {
+        // to ensure that onBackground() is not called twice we
+        // check if the previous app state was 'active'
+        // as iOS has two not-active-states (inactive and background)
+        isValidFunction(onBackground) && onBackground();
+      }
+      setAppState(nextAppState);
+      isValidFunction(onChange) && onChange(nextAppState);
+    }
     AppState.addEventListener('change', handleAppStateChange);
     // didUnmount effect
     return () => AppState.removeEventListener('change', handleAppStateChange);
-  },[]);
-
+  }, [onChange, onForeground, onBackground, appState]);
   // settings validation
   function isValidFunction(func) {
     return func && typeof func === 'function';
   }
-
   return { appState };
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,13 @@ export default function useAppState(settings) {
   function handleAppStateChange(nextAppState) {
     if (nextAppState === 'active') {
       isValidFunction(onForeground) && onForeground();
-    } else if(nextAppState.match(/inactive|background/)) {
+    } else if (
+      appState === 'active' &&
+      nextAppState.match(/inactive|background/)
+    ) {
+      // to ensure that onBackground() is not called twice we
+      // check if the previous app state was 'active' as iOS
+      // has two not-active-states (inactive and background)
       isValidFunction(onBackground) && onBackground();
     }
     setAppState(nextAppState);


### PR DESCRIPTION
Thanks for your work!

This PR fixes two things:
- The background callback sometimes gets called twice on iOS as iOS has two not-active-states (inactive and background). 
- Eslint hints for the empty dependency array:
 `React Hook useEffect has a missing dependency: 'handleAppStateChange'. Either include it or remove the dependency array.eslint(react-hooks/exhaustive-deps)`. 
If you include the dependency then Eslint will complain about the function outside:
 `The 'handleAppStateChange' function makes the dependencies of useEffect Hook (at line 32) change on every render. Move it inside the useEffect callback. Alternatively, wrap the 'handleAppStateChange' definition into its own useCallback() Hook.eslint(react-hooks/exhaustive-deps)`. Moving the function inside and updating the dependencies will fix that.