### PR TITLE
Additional hooks

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -5,33 +5,30 @@ export default function useAppState(settings) {
   const { onChange, onForeground, onBackground } = settings || {};
   const [appState, setAppState] = useState(AppState.currentState);
 
-  function handleAppStateChange(nextAppState) {
-    if (nextAppState === 'active') {
-      isValidFunction(onForeground) && onForeground();
-    } else if (
-      appState === 'active' &&
-      nextAppState.match(/inactive|background/)
-    ) {
-      // to ensure that onBackground() is not called twice we
-      // check if the previous app state was 'active' as iOS
-      // has two not-active-states (inactive and background)
-      isValidFunction(onBackground) && onBackground();
-    }
-    setAppState(nextAppState);
-    isValidFunction(onChange) && onChange(nextAppState);
-  }
-
   // didMount effect
   useEffect(() => {
+    function handleAppStateChange(nextAppState) {
+      if (nextAppState === 'active') {
+        isValidFunction(onForeground) && onForeground();
+      } else if (
+        appState === 'active' &&
+        nextAppState.match(/inactive|background/)
+      ) {
+        // to ensure that onBackground() is not called twice we
+        // check if the previous app state was 'active'
+        // as iOS has two not-active-states (inactive and background)
+        isValidFunction(onBackground) && onBackground();
+      }
+      setAppState(nextAppState);
+      isValidFunction(onChange) && onChange(nextAppState);
+    }
     AppState.addEventListener('change', handleAppStateChange);
     // didUnmount effect
     return () => AppState.removeEventListener('change', handleAppStateChange);
-  },[]);
-
+  }, [onChange, onForeground, onBackground, appState]);
   // settings validation
   function isValidFunction(func) {
     return func && typeof func === 'function';
   }
-
   return { appState };
 }

--- a/dist/index.js
+++ b/dist/index.js
@@ -8,7 +8,13 @@ export default function useAppState(settings) {
   function handleAppStateChange(nextAppState) {
     if (nextAppState === 'active') {
       isValidFunction(onForeground) && onForeground();
-    } else if(nextAppState.match(/inactive|background/)) {
+    } else if (
+      appState === 'active' &&
+      nextAppState.match(/inactive|background/)
+    ) {
+      // to ensure that onBackground() is not called twice we
+      // check if the previous app state was 'active' as iOS
+      // has two not-active-states (inactive and background)
       isValidFunction(onBackground) && onBackground();
     }
     setAppState(nextAppState);

--- a/dist/index.js
+++ b/dist/index.js
@@ -32,3 +32,11 @@ export default function useAppState(settings) {
   }
   return { appState };
 }
+
+export function useOnAppComesToForeground(callback) {
+  return useAppState({ onForeground: callback });
+}
+
+export function useOnAppGoesToBackground(callback) {
+  return useAppState({ onBackground: callback });
+}


### PR DESCRIPTION
This PR is on top of #3.

It adds two additional hooks, so the most common needed functionality is easier and more readable accessible (in my opinion).

This change is non-breaking and just adds additional functionality.

Use it like this:
```
import {
  useOnAppComesToForeground,
  useOnAppGoesToBackground
} from '@hooks/useAppState';

const welcome = () => {
  console.warn('The App just came into the foreground!');
};
useOnAppComesToForeground(welcome);

const goodbye = () => {
  console.warn('The App just went into the background');
};
useOnAppGoesToBackground(goodbye);
```