### PR TITLE
fix: support RN 0.65 by removing deprecated removeEventListener function

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15,9 +15,9 @@ export default function useAppState(settings) {
       setAppState(nextAppState);
       isValidFunction(onChange) && onChange(nextAppState);
     }
-    AppState.addEventListener('change', handleAppStateChange);
-    
-    return () => AppState.removeEventListener('change', handleAppStateChange);
+    const appState = AppState.addEventListener('change', handleAppStateChange);
+
+    return () => appState.remove();
   }, [onChange, onForeground, onBackground, appState]);
 
   // settings validation


### PR DESCRIPTION
**This PR is to solve #11** 

- Starting react-native 0.65, `removeEventListener` from `AppState` is deprecated.

- To avoid warnings when using `useAppState` of react-native-appstate-hook, the code needs to be updated with the new subscription object provided by `AppState` from `react-native`.

- This PR is for this, addapting the code to the new object, functions and requirements.

- **Fully tested**. Working & stable state. The change is easy and simple.